### PR TITLE
Cast to int smtp_port

### DIFF
--- a/src/utils/mail.py
+++ b/src/utils/mail.py
@@ -47,7 +47,7 @@ class MailBook:
     
     def _send_email(self, msg):
         try:
-            smtp = smtplib.SMTP(host=self._smtp_host, port=self._smtp_port)
+            smtp = smtplib.SMTP(host=self._smtp_host, port=int(self._smtp_port))
             smtp.connect(host=self._smtp_host, port=self._smtp_port)
             smtp.ehlo()
             smtp.starttls()


### PR DESCRIPTION
In my Raspberry Pi with OSMC (python 2.7) it doesn't automatically casts the port and crash.